### PR TITLE
add - tools

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ android:
     # Uncomment the lines below if you want to
     # use the latest revision of Android SDK Tools
     # - platform-tools
-    # - tools
+    - tools
 
     # The BuildTools version used by your project
     - build-tools-23.0.2


### PR DESCRIPTION
adding `- tools` ensures Travis CI updates the Android SDK Tools version. 
from: https://docs.travis-ci.com/user/languages/android/#Overview.
